### PR TITLE
Base classes

### DIFF
--- a/saged/datasets.py
+++ b/saged/datasets.py
@@ -79,17 +79,21 @@ class ExpressionDataset(ABC):
         """
         raise NotImplementedError
 
-    def subset_studies(self, fraction: float) -> float:
+    def subset_studies(self, fraction: float = None, num_studies: int = None) -> float:
         """
         This method is similar to `subset_samples`, but removes entire studies until the
         fraction of data remaining is less than the fraction passed in.
 
         As this will almost never result in the fraction being met exactly, the data fraction
-        that actually comes out of the subsetting will be returned
+        that actually comes out of the subsetting will be returned.
+
+        Either `fraction` or `num_studies` must be specified. If both are specified,
+        `num_studies` will be given preference.
 
         Arguments
         ---------
         fraction: The fraction of the samples to keep
+        num_studies: The number of studies to keep
 
         Returns
         -------
@@ -126,13 +130,13 @@ class ExpressionDataset(ABC):
     @abstractmethod
     # For more info on using a forward reference for the type, see
     # https://github.com/python/mypy/issues/3661#issuecomment-313157498
-    def get_cv_splits(self, num_splits) -> Sequence["ExpressionDataset"]:
+    def get_cv_splits(self, num_splits: int) -> Sequence["ExpressionDataset"]:
         """
         Split the dataset into a list of smaller dataset objects with a roughly equal
         number of samples in each.
 
-        If multiple studies are present in the dataset, each dataset should only
-        have data from a single study
+        If multiple studies are present in the dataset, each study should only
+        be present in a single fold
 
         Arguments
         ---------
@@ -141,5 +145,34 @@ class ExpressionDataset(ABC):
         Returns
         -------
         subsets: A list of datasets, each composed of fractions of the original
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def train_test_split(self,
+                         train_fraction: float = None,
+                         train_study_count: int = None
+                        ) -> Sequence["ExpressionDataset"]:
+        """
+        Split the dataset into two portions, as seen in scikit-learn's `train_test_split`
+        function.
+
+        If multiple studies are present in the dataset, each study should only
+        be present in one of the two portions.
+
+        Either `train_fraction` or `train_study_count` must be specified. If both
+        are specified, then `train_study_count` takes precedence.
+
+        Arguments
+        ---------
+        train_fraction: The minimum fraction of the data to be used as training data.
+            In reality, the fraction won't be met entirely due to the constraint of
+            preserving studies.
+        train_study_count: The number of studies to be included in the training set
+
+        Returns
+        -------
+        train: The dataset with around the amount of data specified by train_fraction
+        test: The dataset with the remaining data
         """
         raise NotImplementedError

--- a/saged/datasets.py
+++ b/saged/datasets.py
@@ -1,0 +1,133 @@
+""" This file contains dataset objects for manipulating gene expression data """
+from abc import ABC, abstractmethod
+from typing import Sequence, Tuple
+
+import numpy as np
+
+
+class ExpressionDataset(ABC):
+    """
+    The base dataset defining the API for datasets in this project. This class is
+    based on the Dataset object from pytorch
+    (https://pytorch.org/docs/stable/_modules/torch/utils/data/dataset.html#Dataset
+    """
+    @abstractmethod
+    def __init__(self) -> None:
+        """
+        Abstract initializer. When implemented this function should take in a datasource
+        and use it to initialize the class member variables
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """
+        Return the length of the dataset for use in determining
+        the size of an epoch
+
+        Arguments
+        ---------
+
+        Returns
+        -------
+        length: The number of samples currently available in the dataset
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def __getitem__(self, idx: int) -> Tuple[np.array, np.array]:
+        """
+        Allows access into the dataset to select a single datapoint and
+        its associated label
+
+        Arguments
+        ---------
+
+        Returns
+        -------
+        Returns
+        -------
+        X: The gene expression data for the given index in a genes x 1 array
+        y: The label corresponding to the sample in X
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_sklearn_data(self) -> Tuple[np.array, np.array]:
+        """
+        Returns all the expression data and labels from the dataset in the
+        form of an (X,y) tuple where both X and y are numpy arrays
+
+        Returns
+        -------
+        X: The gene expression data in a genes x samples array
+        y: The label corresponding to each sample in X
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def subset_samples(self, fraction: float) -> None:
+        """
+        Limit the amount of data available to be returned in proportion to
+        the total amount of data that was present in the dataset.
+        That is to say that calling subset_data_by_fraction twice will not cause the Dataset
+        object to have multiplicatively less data, it will have the fraction of data specified
+        in the second call
+
+        Arguments
+        ---------
+        fraction: The fraction of the samples to keep
+        """
+        raise NotImplementedError
+
+    def subset_studies(self, fraction: float) -> float:
+        """
+        This method is similar to subset_samples, but removes entire studies until the
+        fraction of data remaining is less than the fraction passed in.
+
+        As this will almost never result in the fraction being met exactly, the data fraction
+        that actually comes out of the subsetting will be returned
+
+        Arguments
+        ---------
+        fraction: The fraction of the samples to keep
+
+        Returns
+        -------
+        true_fraction: The fraction of the samples that were actually kept
+        """
+        raise NotImplementedError
+
+    def subset_samples_for_label(self, fraction: float, label: str) -> None:
+        """
+        Limit the number of samples available for a single label.
+        For example, if you wanted to use only ten percent of the sepsis expression
+        samples across all studies, you would use this function.
+
+        Arguments
+        ---------
+        fraction: The fraction of the samples to keep
+        label: The category of data to apply this subset to
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    # For more info on using a forward reference for the type, see
+    # https://github.com/python/mypy/issues/3661#issuecomment-313157498
+    def get_cv_splits(self, num_splits) -> Sequence["ExpressionDataset"]:
+        """
+        Split the dataset into a list of smaller dataset objects with a roughly equal
+        number of samples in each.
+
+        If multiple studies are present in the dataset, each dataset should only
+        have data from a single study
+
+        Arguments
+        ---------
+        num_splits: The number of groups to split the dataset into
+
+        Returns
+        -------
+        subsets: A list of datasets, each composed of fractions of the original
+        """
+        raise NotImplementedError

--- a/saged/datasets.py
+++ b/saged/datasets.py
@@ -17,7 +17,7 @@ class ExpressionDataset(ABC):
         Abstract initializer. When implemented this function should take in a datasource
         and use it to initialize the class member variables
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def __len__(self) -> int:
@@ -41,9 +41,8 @@ class ExpressionDataset(ABC):
 
         Arguments
         ---------
+        idx: The index of the given item
 
-        Returns
-        -------
         Returns
         -------
         X: The gene expression data for the given index in a genes x 1 array
@@ -52,7 +51,7 @@ class ExpressionDataset(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_sklearn_data(self) -> Tuple[np.array, np.array]:
+    def get_all_data(self) -> Tuple[np.array, np.array]:
         """
         Returns all the expression data and labels from the dataset in the
         form of an (X,y) tuple where both X and y are numpy arrays
@@ -101,31 +100,6 @@ class ExpressionDataset(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def subset_samples_for_label(self, fraction: float, label: str) -> None:
-        """
-        Limit the number of samples available for a single label.
-        For example, if you wanted to use only ten percent of the sepsis expression
-        samples across all studies, you would use this function.
-
-        Arguments
-        ---------
-        fraction: The fraction of the samples to keep
-        label: The category of data to apply this subset to
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def subset_samples_to_labels(self, labels: List[str]) -> None:
-        """
-        Keep only the samples corresponding to the labels passed in.
-        Stacks with other labels; if `subset_samples_for_label`
-
-        Arguments
-        ---------
-        labels: The label or labels of samples to keep
-        """
-        raise NotImplementedError
 
     @abstractmethod
     # For more info on using a forward reference for the type, see
@@ -174,5 +148,62 @@ class ExpressionDataset(ABC):
         -------
         train: The dataset with around the amount of data specified by train_fraction
         test: The dataset with the remaining data
+        """
+        raise NotImplementedError
+
+
+class LabeledDataset(ExpressionDataset):
+    @abstractmethod
+    def subset_samples_for_label(self, fraction: float, label: str) -> None:
+        """
+        Limit the number of samples available for a single label.
+        For example, if you wanted to use only ten percent of the sepsis expression
+        samples across all studies, you would use this function.
+
+        Arguments
+        ---------
+        fraction: The fraction of the samples to keep
+        label: The category of data to apply this subset to
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def subset_samples_to_labels(self, labels: List[str]) -> None:
+        """
+        Keep only the samples corresponding to the labels passed in.
+        Stacks with other labels; if `subset_samples_for_label`
+
+        Arguments
+        ---------
+        labels: The label or labels of samples to keep
+        """
+        raise NotImplementedError
+
+
+class UnlabeledDataset(ExpressionDataset):
+    @abstractmethod
+    def __getitem__(self, idx: int) -> np.array:
+        """
+        Allows access into the dataset to select a single datapoint
+
+        Arguments
+        ---------
+        idx: The index of the given item
+
+        Returns
+        -------
+        X: The gene expression data for the given index in a genes x 1 array
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_data(self) -> np.array:
+        """
+        Returns all the expression data from the dataset in the
+        form of a numpy array
+
+        Returns
+        -------
+        X: The gene expression data in a genes x samples array
         """
         raise NotImplementedError

--- a/saged/datasets.py
+++ b/saged/datasets.py
@@ -1,6 +1,6 @@
 """ This file contains dataset objects for manipulating gene expression data """
 from abc import ABC, abstractmethod
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, List
 
 import numpy as np
 
@@ -37,8 +37,7 @@ class ExpressionDataset(ABC):
     @abstractmethod
     def __getitem__(self, idx: int) -> Tuple[np.array, np.array]:
         """
-        Allows access into the dataset to select a single datapoint and
-        its associated label
+        Allows access into the dataset to select a single datapoint and its associated label
 
         Arguments
         ---------
@@ -82,7 +81,7 @@ class ExpressionDataset(ABC):
 
     def subset_studies(self, fraction: float) -> float:
         """
-        This method is similar to subset_samples, but removes entire studies until the
+        This method is similar to `subset_samples`, but removes entire studies until the
         fraction of data remaining is less than the fraction passed in.
 
         As this will almost never result in the fraction being met exactly, the data fraction
@@ -98,6 +97,7 @@ class ExpressionDataset(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def subset_samples_for_label(self, fraction: float, label: str) -> None:
         """
         Limit the number of samples available for a single label.
@@ -108,6 +108,18 @@ class ExpressionDataset(ABC):
         ---------
         fraction: The fraction of the samples to keep
         label: The category of data to apply this subset to
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def subset_samples_to_labels(self, labels: List[str]) -> None:
+        """
+        Keep only the samples corresponding to the labels passed in.
+        Stacks with other labels; if `subset_samples_for_label`
+
+        Arguments
+        ---------
+        labels: The label or labels of samples to keep
         """
         raise NotImplementedError
 

--- a/saged/datasets.py
+++ b/saged/datasets.py
@@ -9,7 +9,7 @@ class ExpressionDataset(ABC):
     """
     The base dataset defining the API for datasets in this project. This class is
     based on the Dataset object from pytorch
-    (https://pytorch.org/docs/stable/_modules/torch/utils/data/dataset.html#Dataset
+    (https://pytorch.org/docs/stable/_modules/torch/utils/data/dataset.html#Dataset)
     """
     @abstractmethod
     def __init__(self) -> None:
@@ -64,7 +64,7 @@ class ExpressionDataset(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def subset_samples(self, fraction: float) -> None:
+    def subset_samples(self, fraction: float, seed: int = 42) -> "ExpressionDataset":
         """
         Limit the amount of data available to be returned in proportion to
         the total amount of data that was present in the dataset.
@@ -75,16 +75,21 @@ class ExpressionDataset(ABC):
         Arguments
         ---------
         fraction: The fraction of the samples to keep
+        seed: The seed for the random number generator involved in subsetting
+
+        Returns
+        -------
+        self: The object after subsetting
         """
         raise NotImplementedError
 
-    def subset_studies(self, fraction: float = None, num_studies: int = None) -> float:
+    def subset_studies(self,
+                       fraction: float = None,
+                       num_studies: int = None,
+                       seed: int = 42) -> "ExpressionDataset":
         """
         This method is similar to `subset_samples`, but removes entire studies until the
         fraction of data remaining is less than the fraction passed in.
-
-        As this will almost never result in the fraction being met exactly, the data fraction
-        that actually comes out of the subsetting will be returned.
 
         Either `fraction` or `num_studies` must be specified. If both are specified,
         `num_studies` will be given preference.
@@ -93,18 +98,18 @@ class ExpressionDataset(ABC):
         ---------
         fraction: The fraction of the samples to keep
         num_studies: The number of studies to keep
+        seed: The seed for the random number generator involved in subsetting
 
         Returns
         -------
-        true_fraction: The fraction of the samples that were actually kept
+        self: The object after subsetting
         """
         raise NotImplementedError
-
 
     @abstractmethod
     # For more info on using a forward reference for the type, see
     # https://github.com/python/mypy/issues/3661#issuecomment-313157498
-    def get_cv_splits(self, num_splits: int) -> Sequence["ExpressionDataset"]:
+    def get_cv_splits(self, num_splits: int, seed: int = 42) -> Sequence["ExpressionDataset"]:
         """
         Split the dataset into a list of smaller dataset objects with a roughly equal
         number of samples in each.
@@ -115,6 +120,7 @@ class ExpressionDataset(ABC):
         Arguments
         ---------
         num_splits: The number of groups to split the dataset into
+        seed: The seed for the random number generator involved in subsetting
 
         Returns
         -------
@@ -125,7 +131,8 @@ class ExpressionDataset(ABC):
     @abstractmethod
     def train_test_split(self,
                          train_fraction: float = None,
-                         train_study_count: int = None
+                         train_study_count: int = None,
+                         seed: int = 42,
                         ) -> Sequence["ExpressionDataset"]:
         """
         Split the dataset into two portions, as seen in scikit-learn's `train_test_split`
@@ -143,6 +150,7 @@ class ExpressionDataset(ABC):
             In reality, the fraction won't be met entirely due to the constraint of
             preserving studies.
         train_study_count: The number of studies to be included in the training set
+        seed: The seed for the random number generator involved in subsetting
 
         Returns
         -------
@@ -154,7 +162,10 @@ class ExpressionDataset(ABC):
 
 class LabeledDataset(ExpressionDataset):
     @abstractmethod
-    def subset_samples_for_label(self, fraction: float, label: str) -> None:
+    def subset_samples_for_label(self, fraction: float,
+                                 label: str,
+                                 seed: int = 42,
+                                ) -> "LabeledDataset":
         """
         Limit the number of samples available for a single label.
         For example, if you wanted to use only ten percent of the sepsis expression
@@ -164,11 +175,19 @@ class LabeledDataset(ExpressionDataset):
         ---------
         fraction: The fraction of the samples to keep
         label: The category of data to apply this subset to
+        seed: The seed for the random number generator involved in subsetting
+
+        Returns
+        -------
+        self: The subsetted version of the dataset
         """
         raise NotImplementedError
 
     @abstractmethod
-    def subset_samples_to_labels(self, labels: List[str]) -> None:
+    def subset_samples_to_labels(self,
+                                 labels: List[str],
+                                 seed: int = 42,
+                                 ) -> "LabeledDataset":
         """
         Keep only the samples corresponding to the labels passed in.
         Stacks with other labels; if `subset_samples_for_label`
@@ -176,6 +195,11 @@ class LabeledDataset(ExpressionDataset):
         Arguments
         ---------
         labels: The label or labels of samples to keep
+        seed: The seed for the random number generator involved in subsetting
+
+        Returns
+        -------
+        self: The subsetted version of the dataset
         """
         raise NotImplementedError
 

--- a/saged/models.py
+++ b/saged/models.py
@@ -18,7 +18,7 @@ class ModelResults():
                  model_name: str,
                  progress_type: str,
                  loss_type: str,
-                 accuracy_metric_type: str
+                 metric_type: str
                 ) -> None:
         """
         Initialize the ModelResults object and keep track of its loss and other metrics.
@@ -28,11 +28,11 @@ class ModelResults():
         model_name: The name of the model that produced these results
         progress_type: The unit of the values that will be stored in the progress array
         loss_type: The name of the loss function being used
-        accuracy_metric_type: The name of the accuracy metric being used
+        metric_type: The name of the metric being used
         """
         self.name = model_name
         self.loss_type = loss_type
-        self.accuracy_metric_type = accuracy_metric_type
+        self.metric_type = metric_type
         self.progress_type = progress_type
 
         # Progress stores the number of iterations of type progress_type so far
@@ -47,27 +47,27 @@ class ModelResults():
     def add_progress(self,
                      progress: int,
                      loss: float,
-                     accuracy_metric: float,
+                     metric: float,
                      is_val: bool
                     ) -> None:
         """
-        Update the ModelResults with loss and accuracy metric information
+        Update the ModelResults with loss and metric information
 
         Arguments
         ---------
         progress: The step, epoch, etc. that this entry corresponds to
         loss: The value of the loss function at this time
-        accuracy_metric: The value of the accuracy metric at this time
+        metric: The value of the metric at this time
         is_val: Whether the results should be stored as validation metrics or training metrics
         """
         if is_val:
             self.val_progress.append(progress)
             self.val_loss.append(loss)
-            self.val_metric.append(accuracy_metric)
+            self.val_metric.append(metric)
         else:
             self.train_progress.append(progress)
             self.train_loss.append(loss)
-            self.train_metric.append(accuracy_metric)
+            self.train_metric.append(metric)
 
     def add_other(self,
                   metric_name: str,

--- a/saged/models.py
+++ b/saged/models.py
@@ -1,0 +1,136 @@
+""" A module containing the models to be trained on gene expression data """
+
+from abc import ABC, abstractmethod
+from typing import Union
+
+import numpy as np
+
+from datasets import LabeledDataset
+
+
+class ModelResults():
+    """
+    A structure for storing the metrics corresponding to a model's training.
+    The ModelResults class requires a loss and another metric such as accuracy or F1 score.
+    Other metrics can be tracked via the `add_other` method
+    """
+    def __init__(self,
+                 model_name: str,
+                 progress_type: str,
+                 loss_type: str,
+                 accuracy_metric_type: str
+                ) -> None:
+        """
+        Initialize the ModelResults object and keep track of its loss and other metrics.
+
+        Arguments
+        ---------
+        model_name: The name of the model that produced these results
+        progress_type: The unit of the values that will be stored in the progress array
+        loss_type: The name of the loss function being used
+        accuracy_metric_type: The name of the accuracy metric being used
+        """
+        self.name = model_name
+        self.loss_type = loss_type
+        self.accuracy_metric_type = accuracy_metric_type
+        self.progress_type = progress_type
+
+        # Progress stores the number of iterations of type progress_type so far
+        self.val_progress = []
+        self.train_progress = []
+        self.val_loss = []
+        self.train_loss = []
+        self.val_metric = []
+        self.train_metric = []
+        self.other = {}
+
+    def add_progress(self,
+                     progress: int,
+                     loss: float,
+                     accuracy_metric: float,
+                     is_val: bool
+                    ) -> None:
+        """
+        Update the ModelResults with loss and accuracy metric information
+
+        Arguments
+        ---------
+        progress: The step, epoch, etc. that this entry corresponds to
+        loss: The value of the loss function at this time
+        accuracy_metric: The value of the accuracy metric at this time
+        is_val: Whether the results should be stored as validation metrics or training metrics
+        """
+        if is_val:
+            self.val_progress.append(progress)
+            self.val_loss.append(loss)
+            self.val_metric.append(accuracy_metric)
+        else:
+            self.train_progress.append(progress)
+            self.train_loss.append(loss)
+            self.train_metric.append(accuracy_metric)
+
+    def add_other(self,
+                  metric_name: str,
+                  metric_val: Union[int, float],
+                  metric_progress: int
+                 ) -> None:
+        """
+        Add information about an additional metric to the model
+
+        Arguments
+        ---------
+        metric_name: The name of the metric being recorded
+        metric_val: The value of the metric being recorded
+        metric_progress: The step, epoch, etc. that this entry corresponds to
+        """
+
+        if metric_name in self.other:
+            self.other['metric_name']['vals'].append(metric_val)
+            self.other['metric_name']['progress'].append(metric_progress)
+
+        else:
+            self.other['metric_name'] = {'vals': [metric_val],
+                                         'progress': [metric_progress]
+                                        }
+
+
+class ExpressionModel(ABC):
+    """ A model API similar to the scikit-learn API that will specify the
+    base acceptable functions for models in this module's benchmarking code
+    """
+
+    def __init__(self) -> None:
+        """
+        Standard model init function. We use pass instead of raising a NotImplementedError
+        here in case inheriting classes decide to call `super()`
+        """
+        pass
+
+    @abstractmethod
+    def fit(self, dataset: LabeledDataset) -> ModelResults:
+        """
+        Train a model using the given labeled data
+
+        Arguments
+        ---------
+        dataset: The labeled data for use in training
+
+        Returns
+        -------
+        results: The metrics produced during the training process
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def predict(self, dataset: np.array) -> np.array:
+        """
+
+        Arguments
+        ---------
+        dataset: The unlabeled data whose labels should be predicted
+
+        Returns
+        -------
+        predictions: A numpy array of predictions
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This PR creates the abstract base classes that define the API for models and datsets in the benchmark.

The Model classes will inherit from an API that looks like the sklearn API, and the dataset API is based on pytorch datasets. 
The datasets also fall into two categories, labeled and unlabeled, with different required functions for each.

Questions:
- Is there a clearer way of naming `subset_samples_for_label` and `subset_samples_to_labels`?
- I feel like there should be a better way of recording model results than creating my own class, but I can't think of anything that works for both sklearn and pytorch models
- The only two required functions for the `ExpressionModel` class are `fit` and `predict`. Am I missing anything that should be present in all models?