### PR TITLE
Fix memory leak in PytorchSupervised

### DIFF
--- a/saged/all_label_comparison.py
+++ b/saged/all_label_comparison.py
@@ -110,8 +110,9 @@ if __name__ == '__main__':
 
         # Train the model on the training data
         supervised_model.fit(train_data)
-
         predictions, true_labels = supervised_model.evaluate(val_data)
+
+        supervised_model.free_memory()
 
         # TODO more measures than Top-1 accuracy
         accuracy = sklearn.metrics.accuracy_score(predictions, true_labels)

--- a/saged/models.py
+++ b/saged/models.py
@@ -134,6 +134,15 @@ class ExpressionModel(ABC):
         """
         raise NotImplementedError
 
+    def free_memory(self) -> None:
+        """
+        Some models need help freeing the memory allocated to them. Others do not.
+        This function is a placeholder that can be overridden by inheriting classes
+        if needed. PytorchSupervised is a good example of what a custom free_memory function
+        does.
+        """
+        pass
+
     @abstractmethod
     def fit(self, dataset: LabeledDataset) -> ModelResults:
         """
@@ -408,6 +417,16 @@ class PytorchSupervised(ExpressionModel):
         torch.manual_seed = seed
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
+
+    def free_memory(self) -> None:
+        """
+        The model subclass and optimizer used by PytorchSupervised don't release their
+        GPU memory by default when the main class is deleted. This function fixes that
+
+        See https://github.com/greenelab/saged/issues/9 for more details
+        """
+        del self.model
+        del self.optimizer
 
     @classmethod
     def load_model(classobject,

--- a/saged/models.py
+++ b/saged/models.py
@@ -543,12 +543,14 @@ class PytorchSupervised(ExpressionModel):
             for batch in train_loader:
                 expression, labels = batch
                 expression = expression.float().to(device)
+                labels = labels.squeeze()
+
                 labels = labels.to(device)
 
                 self.optimizer.zero_grad()
                 output = self.model(expression)
 
-                loss = self.loss_fn(output.unsqueeze(-1), labels)
+                loss = self.loss_fn(output, labels)
                 loss.backward()
                 self.optimizer.step()
 

--- a/test/data/test_data_config.yml
+++ b/test/data/test_data_config.yml
@@ -1,5 +1,6 @@
 # These paths are relative to the saged root directory.
 # If you want to run tests from somewhere else, you'll have to modify them
+name: "RefineBioMixedDataset"
 compendium_path: "test/data/test_expression.tsv"
 label_path: "test/data/test_labels.pkl"
 metadata_path: "test/data/test_metadata.json"

--- a/test/data/test_data_config.yml
+++ b/test/data/test_data_config.yml
@@ -1,6 +1,5 @@
 # These paths are relative to the saged root directory.
 # If you want to run tests from somewhere else, you'll have to modify them
-name: "RefineBioMixedDataset"
 compendium_path: "test/data/test_expression.tsv"
 label_path: "test/data/test_labels.pkl"
 metadata_path: "test/data/test_metadata.json"


### PR DESCRIPTION
It turns out that making pytorch models members of a larger class leads to references between the optimizer and model parameters not being deleted or something. Long story short, it's necessary to manually delete the model and optimizer to keep the old tensors from haunting you/causing memory leaks. 

If only there were a function that acted like the opposite of an initializer called `__del__` or something. Unfortunately I tried that and deleting the model and optimizer from `__del__` doesn't work while writing a custom function to do the same thing does *shrug*. I would expect it to be something to do with variable scope, but even if you explicitly call `del` on the model the tensors live on.

This solution works, though the fact that writing a `__del__` function didn't is confusing to me.

Closes #9 