### PR TITLE
Make Transform Act on a Copy

### DIFF
--- a/model_configs/PCA.yml
+++ b/model_configs/PCA.yml
@@ -1,2 +1,3 @@
-n_components: 50
+name: "PCA"
+n_components: 100
 seed: 42

--- a/saged/all_label_comparison.py
+++ b/saged/all_label_comparison.py
@@ -100,6 +100,15 @@ if __name__ == '__main__':
             unsupervised_model.fit(available_data)
             train_data = unsupervised_model.transform(train_data)
 
+            # Embed the validation data
+            val_data = unsupervised_model.transform(val_data)
+
+            # Adjust the input size since we aren't using the original dimensionality
+            input_size = len(train_data.get_features())
+
+            # Reset filters on all_data which were changed to create available_data
+            all_data.reset_filters()
+
         with open(args.supervised_config) as supervised_file:
             supervised_config = yaml.safe_load(supervised_file)
             supervised_config['input_size'] = input_size

--- a/saged/datasets.py
+++ b/saged/datasets.py
@@ -258,6 +258,19 @@ class LabeledDataset(ExpressionDataset):
         raise NotImplementedError
 
     @abstractmethod
+    def get_all_data() -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Returns all the expression data and labels from the dataset in the
+        form of an (X,y) tuple where both X and y are numpy arrays
+
+        Returns
+        -------
+        X: The gene expression data in a samples x genes array
+        y: The label corresponding to each sample in X
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def subset_samples_to_labels(self,
                                  labels: List[str],
                                  ) -> "LabeledDataset":

--- a/saged/models.py
+++ b/saged/models.py
@@ -16,7 +16,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 import saged.utils as utils
-from saged.datasets import LabeledDataset, UnlabeledDataset, MixedDataset
+from saged.datasets import LabeledDataset, UnlabeledDataset, MixedDataset, ExpressionDataset
 
 
 class ModelResults():
@@ -786,9 +786,7 @@ class PCA(UnsupervisedModel):
 
         return self
 
-    def transform(self,
-                  dataset: Union[UnlabeledDataset, MixedDataset]) -> Union[UnlabeledDataset,
-                                                                           MixedDataset]:
+    def transform(self, dataset: ExpressionDataset) -> ExpressionDataset:
         """
         Use the learned embedding from the model to embed the given dataset
 
@@ -798,18 +796,23 @@ class PCA(UnsupervisedModel):
 
         Returns
         -------
-        dataset: The transformed version of the dataset passed in
+        dataset_copy: The transformed version of a copy of the dataset passed in
         """
         if issubclass(type(dataset), LabeledDataset):
             X = dataset.get_all_data()[0]
         else:
             X = dataset.get_all_data()
-        print(X)
         X_embedded = self.model.transform(X)
 
-        dataset.set_all_data(X_embedded.T)
+        # This is necessary to match the sklearn API by not overwriting the original dataset
+        # There may be an edge case where this breaks the get_studies function since the
+        # transformed and original dataset will share references to `is_changed`, but I don't
+        # think that will be the case.
+        dataset_copy = copy.copy(dataset)
 
-        return dataset
+        dataset_copy.set_all_data(X_embedded.T)
+
+        return dataset_copy
 
     def save_model(self, out_path: str) -> None:
         """

--- a/saged/models.py
+++ b/saged/models.py
@@ -736,7 +736,8 @@ class PCA(UnsupervisedModel):
     """
     def __init__(self,
                  n_components: int,
-                 seed: int = 42) -> None:
+                 seed: int = 42,
+                 **kwargs) -> None:
         """
         PCA initialization function
 
@@ -777,7 +778,10 @@ class PCA(UnsupervisedModel):
         -------
         self: The trained version of the model
         """
-        X = dataset.get_all_data()
+        if issubclass(type(dataset), LabeledDataset):
+            X = dataset.get_all_data()[0]
+        else:
+            X = dataset.get_all_data()
         self.model = self.model.fit(X)
 
         return self
@@ -796,7 +800,11 @@ class PCA(UnsupervisedModel):
         -------
         dataset: The transformed version of the dataset passed in
         """
-        X = dataset.get_all_data()
+        if issubclass(type(dataset), LabeledDataset):
+            X = dataset.get_all_data()[0]
+        else:
+            X = dataset.get_all_data()
+        print(X)
         X_embedded = self.model.transform(X)
 
         dataset.set_all_data(X_embedded.T)


### PR DESCRIPTION
The `transform` method of unsupervised models previously modified the original dataset instead of a copy. As a result, the folds would be modified during CV, and the merged datasets on the second fold would contain both dimensionally reduced and raw data.

Now that `transform` acts on copies this doesn't happen anymore.