### PR TITLE
Multi tissue

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -238,6 +238,11 @@ rule all:
                supervised=SUPERVISED,
                seed=range(0,NUM_SEEDS),
                ),
+        # Multi-tissue prediction
+        expand("results/all-tissue.{supervised}_{seed}.tsv",
+               supervised=SUPERVISED,
+               seed=range(0,NUM_SEEDS),
+               ),
 
 rule pickle_compendium:
     input:
@@ -629,3 +634,18 @@ rule tissue_prediction:
         "--seed {wildcards.seed} "
         "--tissue1 {wildcards.tissue1} "
         "--tissue2 {wildcards.tissue2} "
+
+rule all_tissue_prediction:
+    threads: 8
+    input:
+        "dataset_configs/recount_dataset.yml",
+        supervised_model = "model_configs/supervised/{supervised}.yml",
+        dataset_config = "dataset_configs/recount_dataset.yml",
+    output:
+        "results/all-tissue.{supervised}_{seed}.tsv"
+    shell:
+        "python saged/predict_tissue.py {input.dataset_config} {input.supervised_model} "
+        "results/all-tissue.{wildcards.supervised}_{wildcards.seed}.tsv "
+        "--neptune_config neptune.yml "
+        "--seed {wildcards.seed} "
+        "--all_tissue"

--- a/model_configs/supervised/pytorch_lr.yml
+++ b/model_configs/supervised/pytorch_lr.yml
@@ -6,7 +6,7 @@ lr: .001
 weight_decay: 0
 device: "cuda"
 seed: 42
-epochs: 10
+epochs: 50
 batch_size: 16
 experiment_name: "PytorchLR"
 experiment_description: "Train a supervised pytorch model"

--- a/notebook/converted/benchmark_results.py
+++ b/notebook/converted/benchmark_results.py
@@ -1092,7 +1092,7 @@ in_files = glob.glob('../../results/Blood.Breast.*.tsv')
 print(in_files[:5])
 
 
-# In[6]:
+# In[3]:
 
 
 tissue_metrics = pd.DataFrame()
@@ -1115,13 +1115,61 @@ tissue_metrics['supervised'] = tissue_metrics['supervised'].str.replace('pytorch
 tissue_metrics
 
 
-# In[8]:
+# In[4]:
 
 
 plot = ggplot(tissue_metrics, aes(x='train_count', y='balanced_accuracy', color='supervised')) 
 plot += geom_smooth()
 plot += geom_point(alpha=.2)
 plot += geom_hline(yintercept=.5, linetype='dashed')
-plot += ggtitle('Brain vs Breast Tissue Prediction')
+plot += ggtitle('Blood vs Breast Tissue Prediction')
 plot
+
+
+# ### All Tissue Predictions
+
+# In[5]:
+
+
+in_files = glob.glob('../../results/all-tissue.*.tsv')
+print(in_files[:5])
+
+
+# In[6]:
+
+
+tissue_metrics = pd.DataFrame()
+for path in in_files:
+    new_df = pd.read_csv(path, sep='\t')
+    model_info = path.strip('.tsv').split('all-tissue.')[-1]
+    model_info = model_info.split('_')
+        
+    supervised_model = '_'.join(model_info[:2])
+             
+    new_df['supervised'] = supervised_model
+    
+    new_df['seed'] = model_info[-1]
+        
+    tissue_metrics = pd.concat([tissue_metrics, new_df])
+    
+tissue_metrics['train_count'] = tissue_metrics['train sample count']
+
+tissue_metrics['supervised'] = tissue_metrics['supervised'].str.replace('pytorch_supervised', 'three_layer_net')
+tissue_metrics
+
+
+# In[9]:
+
+
+plot = ggplot(tissue_metrics, aes(x='train_count', y='balanced_accuracy', color='supervised')) 
+plot += geom_smooth()
+plot += geom_point(alpha=.2)
+plot += ggtitle('Multiclass Tissue Prediction')
+plot
+
+
+# In[ ]:
+
+
+
 

--- a/saged/predict_tissue.py
+++ b/saged/predict_tissue.py
@@ -9,6 +9,17 @@ import yaml
 
 from saged import utils, datasets, models
 
+AVAILABLE_TISSUES = ['Blood', 'Breast', 'Stem Cell', 'Cervix', 'Brain', 'Kidney',
+                     'Umbilical Cord', 'Lung', 'Epithelium', 'Prostate', 'Liver',
+                     'Heart', 'Skin', 'Colon', 'Bone Marrow', 'Muscle', 'Tonsil', 'Blood Vessel',
+                     'Spinal Cord', 'Testis', 'Placenta', 'Bladder', 'Adipose Tisse', 'Ovary',
+                     'Melanoma', 'Adrenal Gland', 'Bone', 'Pancreas', 'Penis',
+                     'Universal reference', 'Spleen', 'Brain reference', 'Large Intestine',
+                     'Esophagus', 'Small Intestine', 'Embryonic kidney', 'Thymus', 'Stomach',
+                     'Endometrium', 'Glioblastoma', 'Gall bladder', 'Lymph Nodes', 'Airway',
+                     'Appendix', 'Thyroid', 'Retina', 'Bowel tissue', 'Foreskin', 'Sperm', 'Foot',
+                     'Cerebellum', 'Cerebral cortex', 'Salivary Gland', 'Duodenum'
+                     ]
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -22,10 +33,10 @@ if __name__ == '__main__':
                         help='The file to save the results to')
     parser.add_argument('--tissue1',
                         help='The first tissue to be predicted from the data',
-                        default='Blood')
+                        default='Blood', choices=AVAILABLE_TISSUES)
     parser.add_argument('--tissue2',
                         help='The second tissue to be predicted from the data',
-                        default='Breast')
+                        default='Breast', choices=AVAILABLE_TISSUES)
     parser.add_argument('--neptune_config',
                         help='A yaml formatted file containing init information for '
                              'neptune logging')
@@ -40,7 +51,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch_correction_method',
                         help='The method to use to correct for batch effects',
                         default=None)
-    parser.add_argument('--all_tissue', help='Predict all frequent tissues in the dataset',
+    parser.add_argument('--all_tissue', help='Predict all common tissues in the dataset',
                         default=False, action='store_true')
 
     args = parser.parse_args()

--- a/saged/predict_tissue.py
+++ b/saged/predict_tissue.py
@@ -68,8 +68,8 @@ if __name__ == '__main__':
         # Keep all labels with at least ten studies in the dataset
         labels_to_keep = ['Blood', 'Breast', 'Stem Cell', 'Cervix', 'Brain', 'Kidney',
                           'Umbilical Cord', 'Lung', 'Epithelium', 'Prostate', 'Liver',
-                          'Heart', 'Skin', 'Colon', 'Bone Marrow', 'Muscle', 'Tonsil', 'Blood Vessel',
-                          'Spinal Cord', 'Testis', 'Placenta'
+                          'Heart', 'Skin', 'Colon', 'Bone Marrow', 'Muscle', 'Tonsil',
+                          'Blood Vessel', 'Spinal Cord', 'Testis', 'Placenta'
                           ]
     else:
         labels_to_keep = [args.tissue1, args.tissue2]


### PR DESCRIPTION
This PR trains models to perform a multitask prediction task where a given sample of gene expression is classified into one of 21 tissue types. 

Changes
- Added the `choices` field in `predict_tissues` and fixed a title in `benchmark_results.ipynb` as requested in https://github.com/greenelab/saged/pull/46
- Updated the Snakefile to run `predict_tissues` with the new `--all-tissue` flag
- Added the `--all-tissue` flag to `predict_tissues`. This flag runs a multitask prediction for all labels with at least ten studies in the dataset