### PR TITLE
Batch effect correction and deeper models

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -238,11 +238,22 @@ rule all:
                supervised=SUPERVISED,
                seed=range(0,NUM_SEEDS),
                ),
+        # Blood tissue vs breast tissue be corrected
+        expand("results/Blood.Breast.{supervised}_{seed}_be_corrected.tsv",
+               supervised=SUPERVISED,
+               seed=range(0,NUM_SEEDS),
+               ),
         # Multi-tissue prediction
         expand("results/all-tissue.{supervised}_{seed}.tsv",
                supervised=SUPERVISED,
                seed=range(0,NUM_SEEDS),
                ),
+        # Multi-tissue prediction be_corrected
+        expand("results/all-tissue.{supervised}_{seed}_be_corrected.tsv",
+               supervised=SUPERVISED,
+               seed=range(0,NUM_SEEDS),
+               ),
+
 
 rule pickle_compendium:
     input:
@@ -648,4 +659,37 @@ rule all_tissue_prediction:
         "results/all-tissue.{wildcards.supervised}_{wildcards.seed}.tsv "
         "--neptune_config neptune.yml "
         "--seed {wildcards.seed} "
-        "--all_tissue"
+        "--all_tissue "
+
+rule tissue_prediction_be_corrected:
+    threads: 8
+    input:
+        "dataset_configs/recount_dataset.yml",
+        supervised_model = "model_configs/supervised/{supervised}.yml",
+        dataset_config = "dataset_configs/recount_dataset.yml",
+    output:
+        "results/{tissue1}.{tissue2}.{supervised}_{seed}_be_corrected.tsv"
+    shell:
+        "python saged/predict_tissue.py {input.dataset_config} {input.supervised_model} "
+        "results/{wildcards.tissue1}.{wildcards.tissue2}.{wildcards.supervised}_{wildcards.seed}_be_corrected.tsv "
+        "--neptune_config neptune.yml "
+        "--seed {wildcards.seed} "
+        "--tissue1 {wildcards.tissue1} "
+        "--tissue2 {wildcards.tissue2} "
+        "--batch_correction_method limma "
+
+rule all_tissue_prediction_be_corrected:
+    threads: 8
+    input:
+        "dataset_configs/recount_dataset.yml",
+        supervised_model = "model_configs/supervised/{supervised}.yml",
+        dataset_config = "dataset_configs/recount_dataset.yml",
+    output:
+        "results/all-tissue.{supervised}_{seed}_be_corrected.tsv"
+    shell:
+        "python saged/predict_tissue.py {input.dataset_config} {input.supervised_model} "
+        "results/all-tissue.{wildcards.supervised}_{wildcards.seed}_be_corrected.tsv "
+        "--neptune_config neptune.yml "
+        "--seed {wildcards.seed} "
+        "--all_tissue "
+        "--batch_correction_method limma "

--- a/model_configs/supervised/deep_net.yml
+++ b/model_configs/supervised/deep_net.yml
@@ -8,7 +8,7 @@ device: "cuda"
 seed: 42
 epochs: 50
 batch_size: 16
-experiment_name: "PytorchSupervised"
+experiment_name: "5 Layer classifier"
 experiment_description: "Train a supervised pytorch model"
 log_progress: True
 train_fraction: .8

--- a/model_configs/supervised/nine_layer.yml
+++ b/model_configs/supervised/nine_layer.yml
@@ -1,0 +1,19 @@
+name: "PytorchSupervised"
+optimizer_name: "Adam"
+loss_name: "CrossEntropyLoss"
+model_name: "GeneralClassifier"
+lr: .00001
+weight_decay: 0
+device: "cuda"
+seed: 42
+epochs: 50
+batch_size: 16
+intermediate_layers: 7
+experiment_name: "9 Layer classifier"
+experiment_description: "Train a supervised pytorch model"
+log_progress: True
+train_fraction: .8
+save_path: "logs/models/pytorch_supervised.pt"
+clip_grads: True
+
+# config.input_size and config.output_size should be set dynamically

--- a/model_configs/supervised/pytorch_supervised.yml
+++ b/model_configs/supervised/pytorch_supervised.yml
@@ -8,7 +8,7 @@ device: "cuda"
 seed: 42
 epochs: 50
 batch_size: 16
-experiment_name: "PytorchSupervised"
+experiment_name: "Three layer net"
 experiment_description: "Train a supervised pytorch model"
 log_progress: True
 train_fraction: .8

--- a/model_configs/supervised/seven_layer.yml
+++ b/model_configs/supervised/seven_layer.yml
@@ -1,0 +1,19 @@
+name: "PytorchSupervised"
+optimizer_name: "Adam"
+loss_name: "CrossEntropyLoss"
+model_name: "GeneralClassifier"
+lr: .00001
+weight_decay: 0
+device: "cuda"
+seed: 42
+epochs: 50
+batch_size: 16
+intermediate_layers: 5
+experiment_name: "7 Layer classifier"
+experiment_description: "Train a supervised pytorch model"
+log_progress: True
+train_fraction: .8
+save_path: "logs/models/pytorch_supervised.pt"
+clip_grads: True
+
+# config.input_size and config.output_size should be set dynamically

--- a/notebook/converted/benchmark_results.py
+++ b/notebook/converted/benchmark_results.py
@@ -1089,6 +1089,7 @@ plot
 
 
 in_files = glob.glob('../../results/Blood.Breast.*.tsv')
+in_files = [f for f in in_files if 'be_corrected' not in f]
 print(in_files[:5])
 
 
@@ -1126,16 +1127,61 @@ plot += ggtitle('Blood vs Breast Tissue Prediction')
 plot
 
 
-# ### All Tissue Predictions
+# ### BE Corrected binary tissue classification
 
 # In[5]:
 
 
-in_files = glob.glob('../../results/all-tissue.*.tsv')
+in_files = glob.glob('../../results/Blood.Breast.*.tsv')
+in_files = [f for f in in_files if 'be_corrected' in f]
 print(in_files[:5])
 
 
 # In[6]:
+
+
+tissue_metrics = pd.DataFrame()
+for path in in_files:
+    new_df = pd.read_csv(path, sep='\t')
+    model_info = path.strip('.tsv').split('Breast.')[-1]
+    model_info = model_info.split('_')
+        
+    supervised_model = '_'.join(model_info[:2])
+             
+    new_df['supervised'] = supervised_model
+    
+    new_df['seed'] = model_info[-1]
+        
+    tissue_metrics = pd.concat([tissue_metrics, new_df])
+    
+tissue_metrics['train_count'] = tissue_metrics['train sample count']
+
+tissue_metrics['supervised'] = tissue_metrics['supervised'].str.replace('pytorch_supervised', 'three_layer_net')
+tissue_metrics
+
+
+# In[7]:
+
+
+plot = ggplot(tissue_metrics, aes(x='train_count', y='balanced_accuracy', color='supervised')) 
+plot += geom_smooth()
+plot += geom_point(alpha=.2)
+plot += geom_hline(yintercept=.5, linetype='dashed')
+plot += ggtitle('Blood vs Breast Tissue Prediction')
+plot
+
+
+# ### All Tissue Predictions
+
+# In[8]:
+
+
+in_files = glob.glob('../../results/all-tissue.*.tsv')
+in_files = [f for f in in_files if 'be_corrected' not in f]
+print(in_files[:5])
+
+
+# In[9]:
 
 
 tissue_metrics = pd.DataFrame()
@@ -1155,10 +1201,11 @@ for path in in_files:
 tissue_metrics['train_count'] = tissue_metrics['train sample count']
 
 tissue_metrics['supervised'] = tissue_metrics['supervised'].str.replace('pytorch_supervised', 'three_layer_net')
+tissue_metrics['supervised'] = tissue_metrics['supervised'].str.replace('deep_net', 'five_layer_net')
 tissue_metrics
 
 
-# In[9]:
+# In[10]:
 
 
 plot = ggplot(tissue_metrics, aes(x='train_count', y='balanced_accuracy', color='supervised')) 

--- a/saged/models.py
+++ b/saged/models.py
@@ -469,6 +469,7 @@ class ImputePerformer(nn.Module):
 
 class FCBlock(nn.Module):
     def __init__(self, input_size: int, output_size: int):
+        super(FCBlock, self).__init__()
         DROPOUT_PROB = .5
         self.fc = nn.Linear(input_size, output_size)
         self.bn = nn.BatchNorm1d(output_size)
@@ -497,7 +498,7 @@ class GeneralClassifier(nn.Module):
                              of layers will be intermediate_layers + 2
         output_size: The number of classes to predict
         """
-        super(DeepClassifier, self).__init__()
+        super(GeneralClassifier, self).__init__()
 
         self.l1 = FCBlock(input_size, input_size // 2)
 
@@ -511,7 +512,8 @@ class GeneralClassifier(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.l1(x)
-        x = self.intermediate(x)
+        for layer in self.intermediate:
+            x = layer(x)
         x = self.output(x)
 
         return x

--- a/saged/predict_tissue.py
+++ b/saged/predict_tissue.py
@@ -76,19 +76,17 @@ if __name__ == '__main__':
 
     labeled_data.subset_samples_to_labels(labels_to_keep)
 
-    # Load binary data subsets the data to two classes. Update the label encoder to treat this
-    # data as binary so the F1 score doesn't break
+    # Correct for batch effects
+    if args.batch_correction_method is not None:
+        labeled_data = all_data.get_labeled()
+        labeled_data.subset_samples_to_labels(labels_to_keep)
+        labeled_data = datasets.correct_batch_effects(labeled_data, args.batch_correction_method)
+
     labeled_data.recode()
     label_encoder = labeled_data.get_label_encoder()
 
-    # Correct for batch effects
-    if args.batch_correction_method is not None:
-        all_data = datasets.correct_batch_effects(all_data, args.batch_correction_method)
-        labeled_data = all_data.get_labeled()
-        labeled_data.subset_samples_to_labels(labels_to_keep)
-        unlabeled_data = all_data.get_unlabeled()
-
     # Get fivefold cross-validation splits
+    print('CV splitting')
     labeled_splits = labeled_data.get_cv_splits(num_splits=args.num_splits, seed=args.seed)
 
     # Train the model on each fold


### PR DESCRIPTION
This notebook examines the effects of batch effect correcting the data and running deeper models.

Results:
- LIMMA removes all the linear signals that are batch dependent. Because the tissue and study are heavily confounded, this removes all the biological signal models like LR would be able to detect. The nonlinear models can still find something, but performance is much worse
- Deeper models perform less well than the five layer neural network. I'd suspect this is due to vanishing gradients since I haven't added skip-connections or anything. Looks like the five layer network is the sweet spot for this dataset, and I'll avoid anything larger because those models take 5ever to train.

BE corrected binary classification:
![image](https://user-images.githubusercontent.com/15317110/128571118-07367869-a998-46c4-bd84-bf9c6305bd65.png)

More models on multiclass:
![image](https://user-images.githubusercontent.com/15317110/128571124-a5c0d713-9780-4af3-b312-f89193dc5d82.png)


Changes: 
- Wrote new config files for the new models
- Visualized the results in the `benchmark_results` notebook
- Implemented a new class for arbitrarily deep fairly rectangular neural networks in `models.py`
- Modified `predict_tissues` to correct batch effects only on the labeled data because limma/combat wanted ~100s of GBs to batch effect correct the whole dataset