### PR TITLE
Label correction

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -80,6 +80,16 @@ rule all:
                supervised=SUPERVISED,
                seed=range(0,NUM_SEEDS),
                ),
+        # sample_split be_corrected
+        expand("results/sample-split-study-corrected.{supervised}_{seed}.tsv",
+               supervised=SUPERVISED,
+               seed=range(0,NUM_SEEDS),
+               ),
+        # study_split be_corrected
+        expand("results/study-split-study-corrected.{supervised}_{seed}.tsv",
+               supervised=SUPERVISED,
+               seed=range(0,NUM_SEEDS),
+               ),
         # tissue_split
         expand("results/tissue-split.{supervised}_{seed}.tsv",
                supervised=SUPERVISED,
@@ -309,6 +319,23 @@ rule sample_level_control_signal_removed:
         "--weighted_loss "
         "--signal_removal "
 
+rule sample_level_be_corrected:
+    threads: 8
+    input:
+        "dataset_configs/recount_dataset.yml",
+        supervised_model = "model_configs/supervised/{supervised}.yml",
+        dataset_config = "dataset_configs/recount_dataset.yml",
+    output:
+        "results/sample-split-study-corrected.{supervised}_{seed}.tsv"
+    shell:
+        "python saged/sample_split_control.py {input.dataset_config} {input.supervised_model} "
+        "results/sample-split-study-corrected.{wildcards.supervised}_{wildcards.seed}.tsv "
+        "--neptune_config neptune.yml "
+        "--seed {wildcards.seed} "
+        "--sample_split "
+        "--weighted_loss "
+        "--study_correct  "
+
 rule study_level_control:
     threads: 8
     input:
@@ -324,7 +351,7 @@ rule study_level_control:
         "--seed {wildcards.seed} "
         "--weighted_loss "
 
-rule study_level_control_sex_prediction:
+rule study_level_sex_prediction:
     threads: 8
     input:
         "dataset_configs/recount_dataset.yml",
@@ -341,7 +368,7 @@ rule study_level_control_sex_prediction:
         "--weighted_loss "
         "--sex_label_path data/combined_human_mouse_meta_v2.csv "
 
-rule study_level_control_signal_removed:
+rule study_level_signal_removed:
     threads: 8
     input:
         "dataset_configs/recount_dataset.yml",
@@ -355,6 +382,23 @@ rule study_level_control_signal_removed:
         "--neptune_config neptune.yml "
         "--seed {wildcards.seed} "
         "--weighted_loss "
+        "--signal_removal "
+
+rule study_level_be_corrected:
+    threads: 8
+    input:
+        "dataset_configs/recount_dataset.yml",
+        supervised_model = "model_configs/supervised/{supervised}.yml",
+        dataset_config = "dataset_configs/recount_dataset.yml",
+    output:
+        "results/study-split-study-corrected.{supervised}_{seed}.tsv"
+    shell:
+        "python saged/sample_split_control.py {input.dataset_config} {input.supervised_model} "
+        "results/study-split-study-corrected.{wildcards.supervised}_{wildcards.seed}.tsv "
+        "--neptune_config neptune.yml "
+        "--seed {wildcards.seed} "
+        "--weighted_loss "
+        "--study_correct  "
 
 rule tissue_split:
     threads: 8

--- a/Snakefile
+++ b/Snakefile
@@ -300,7 +300,7 @@ rule sample_level_control_sex_prediction:
         "--seed {wildcards.seed} "
         "--sample_split "
         "--weighted_loss "
-        "--sex_label_path data/combined_human_mouse_meta_v2.csv "
+        "--use_sex_labels "
 
 rule sample_level_control_signal_removed:
     threads: 8
@@ -366,7 +366,7 @@ rule study_level_sex_prediction:
         "--neptune_config neptune.yml "
         "--seed {wildcards.seed} "
         "--weighted_loss "
-        "--sex_label_path data/combined_human_mouse_meta_v2.csv "
+        "--use_sex_labels "
 
 rule study_level_signal_removed:
     threads: 8

--- a/saged/normalize_recount_data.py
+++ b/saged/normalize_recount_data.py
@@ -18,7 +18,7 @@ def parse_gene_lengths(file_path: str) -> Dict[str, int]:
 
     Returns
     -------
-    gene_to_len - A dict mapping ensembl gene ids to their lenght in base pairs
+    gene_to_len - A dict mapping ensembl gene ids to their length in base pairs
     """
     gene_to_len = {}
     with open(file_path) as in_file:

--- a/saged/sample_split_control.py
+++ b/saged/sample_split_control.py
@@ -56,6 +56,10 @@ if __name__ == '__main__':
                         help='If this flag is set, limma will be used to remove linear signals '
                              'associated with the labels',
                         action='store_true')
+    parser.add_argument('--study_correct',
+                        help='If this flag is set, limma will be used to remove linear signals '
+                             'associated with the studies',
+                        action='store_true')
 
     args = parser.parse_args()
 
@@ -78,6 +82,9 @@ if __name__ == '__main__':
 
     if args.signal_removal:
         labeled_data = datasets.correct_batch_effects(labeled_data, 'limma', 'labels')
+
+    if args.study_correct:
+        labeled_data = datasets.correct_batch_effects(labeled_data, 'limma', 'studies')
 
     # Train the model on each fold
     train_studies = []
@@ -222,7 +229,9 @@ if __name__ == '__main__':
 
                         if args.signal_removal:
                             model_save_path += '-signal-removed'
-                        model_save_path += '_'
+
+                        if args.study_correct:
+                            model_save_path += '-study-corrected'
 
                         # Model class
                         model_save_path += '{}_'.format(model_config['name'])


### PR DESCRIPTION
We decided to look at the results when the linear tissue signal was removed from samples via Limma before prediction. In theory, deep networks should be able to learn nonlinear signal and do better, but the 21-class tissue prediction problem may be too difficult.

Changes:
- Added relevant rules to Snakefile
- Removed old disease-prediction logic from benchmark_Results
- Visualized results in benchmark_results
- Added logic to remove study and tissue signals to sample_split_control